### PR TITLE
Fix issues with auto_entityset

### DIFF
--- a/autonormalize/normalize.py
+++ b/autonormalize/normalize.py
@@ -76,6 +76,7 @@ def make_indexes(depdf):
     Arguments:
         depdf (DepDF) : depDF to make indexes for
     """
+
     prim_key = depdf.deps.get_prim_key()
 
     if len(prim_key) > 1:
@@ -103,8 +104,9 @@ def make_indexes(depdf):
 
                 for index in indices[name]:
                     add[index] = new_val
-
-            depdf.parent.df.drop(columns=prim_key, inplace=True)
+            # Don't drop a column if it is needed in another parent relationship
+            to_drop = [key for key in prim_key if key not in depdf.parent.deps.serialize().keys()]
+            depdf.parent.df.drop(columns=to_drop, inplace=True)
             depdf.parent.df.insert(len(depdf.parent.df.columns), '_'.join(prim_key), add)
 
     for child in depdf.children:

--- a/autonormalize/tests/test_dfd.py
+++ b/autonormalize/tests/test_dfd.py
@@ -1,5 +1,6 @@
 import os
 
+import numpy as np
 import pandas as pd
 
 from autonormalize import dfd
@@ -73,21 +74,28 @@ def test_compute_partitions():
     assert not dfd.compute_partitions(df, 'c', frozenset(['a', 'b']), {}, 0.96, mask)
 
 
-# def test_approximate_dependencies():
-#     mask = dfd.Masks(['a', 'b', 'c'])
-#     a = [6, 2, 3, 7, 8, 1, 0, 2, 0, 3, 6, 0, 4, 6, 8, 7, 6, 8, 1, 5, 1, 3, 3, 0, 0, 4, 5, 5, 7, 0, 8, 2, 4, 7, 0, 0, 6, 4, 6, 8]
-#     # b = [int(x%2 == 0) for x in a]
-#     b = [1, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1]
-#     # c = [(a[i] + b[i])<4 for i in range(40)]
-#     c = [False, True, True, False, False, True, True, True, True, True, False, True, False, False, False, False, False, False, True, False, True, True, True, True, True, False, False, False, False, True, False, True, False, False, True, True, False, False, False, False]
-#     df = pd.DataFrame({'a': a, 'b': b, 'c': c})
-#     assert dfd.approximate_dependencies([0, 1], 2, df, 1.00, mask, 0.90)
-#     assert dfd.approximate_dependencies(set([0, 1]), 2, df, .90, mask, 0.90)
-#     c[0] = True
-#     df = pd.DataFrame({'a': a, 'b': b, 'c': c})
-#     assert dfd.approximate_dependencies([0, 1], 2, df, .97, mask, 0.90)
-#     assert not dfd.approximate_dependencies(set([0, 1]), 2, df, .98, mask, 0.90)
-#     c[35] = False
-#     df = pd.DataFrame({'a': a, 'b': b, 'c': c})
-#     assert dfd.approximate_dependencies([0, 1], 2, df, .95, mask, 0.90)
-#     assert not dfd.approximate_dependencies([0, 1], 2, df, .96, mask, 0.90)
+def test_approximate_dependencies():
+    mask = dfd.Masks(['a', 'b', 'c'])
+    a = [6, 2, 3, 7, 8, 1, 0, 2, 0, 3, 6, 0, 4, 6, 8, 7, 6, 8, 1, 5, 1, 3, 3, 0, 0, 4, 5, 5, 7, 0, 8, 2, 4, 7, 0, 0, 6, 4, 6, 8]
+    b = [1, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1]
+    c = [False, True, True, False, False, True, True, True, True, True, False, True, False, False, False, False, False, False, True, False, True, True, True, True, True, False, False, False, False, True, False, True, False, False, True, True, False, False, False, False]
+    df = pd.DataFrame({'a': a, 'b': b, 'c': c})
+    assert dfd.approximate_dependencies(['a', 'b'], 'c', df, 1.00, mask)
+    assert dfd.approximate_dependencies(['a', 'b'], 'c', df, .90, mask)
+    c[0] = True
+    df = pd.DataFrame({'a': a, 'b': b, 'c': c})
+    assert dfd.approximate_dependencies(['a', 'b'], 'c', df, .97, mask)
+    assert not dfd.approximate_dependencies(['a', 'b'], 'c', df, .98, mask)
+    c[35] = False
+    df = pd.DataFrame({'a': a, 'b': b, 'c': c})
+    assert dfd.approximate_dependencies(['a', 'b'], 'c', df, .95, mask)
+    assert not dfd.approximate_dependencies(['a', 'b'], 'c', df, .96, mask)
+
+
+def test_approximate_dependencies_with_nan():
+    mask = dfd.Masks(['a', 'b', 'c'])
+    a = [np.nan, 2, 3, 7, 8, 1, 0, 2, 0, 3, np.nan, 0, 4, np.nan, 8, 7, np.nan, 8, 1, 5, 1, 3, 3, 0, 0, 4, 5, 5, 7, 0, 8, 2, 4, 7, 0, 0, np.nan, 4, np.nan, 8]
+    b = [1, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1]
+    c = [True, True, True, False, False, True, True, True, True, True, False, True, False, False, False, False, False, False, True, False, True, True, True, True, True, False, False, False, False, True, False, True, False, False, True, True, False, False, False, False]
+    df = pd.DataFrame({'a': a, 'b': b, 'c': c})
+    assert dfd.approximate_dependencies(['a', 'b'], 'c', df, 0.9, mask)


### PR DESCRIPTION
This PR fixes two issues that were identified when trying to replicate the error described in Issue #19 

The first change addresses a problem that resulted by trying to do an `==` comparison between `nan` values.

The second change fixes an issue that can happen causing a column that is needed in other relationships to be dropped from an entity when `make_indexes` is executed.

Two additional tests were added to cover these scenarios.

Also, note, while these issues were discovered when testing for Issue #19, that specific error was not reproduced and it is unknown whether these changes will resolve that issue or not.