### PR TITLE
Use pytest-cov plugin for CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           name: Unit Tests
           command: |
             source python/bin/activate
-            pytest autonormalize/
+            pytest autonormalize/ --cov=autonormalize
       - when:
           condition: << parameters.codecov >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ jobs:
           name: Unit Tests
           command: |
             source python/bin/activate
+            cd package
             pytest autonormalize/ --cov=autonormalize
       - when:
           condition: << parameters.codecov >>


### PR DESCRIPTION
Use coverage plugin for pytest for the CI tests so we have a coverage report to upload to codecov