### PR TITLE
Fix non-deterministic column names created by make_indexes

### DIFF
--- a/autonormalize/classes.py
+++ b/autonormalize/classes.py
@@ -329,6 +329,8 @@ class Dependencies(object):
             prim_key (list[str], optional) : the primary key of the dependencies
         """
         assert prim_key is None or isinstance(prim_key, list)
+        if isinstance(prim_key, list):
+            prim_key.sort()
         if isinstance(dependencies, dict):
             self._data = dependencies
         else:
@@ -343,6 +345,8 @@ class Dependencies(object):
             prim_key (list[str]) : primary key to set
         """
         assert prim_key is None or isinstance(prim_key, list)
+        if isinstance(prim_key, list):
+            prim_key.sort()
         self._primkey = prim_key
 
     def get_prim_key(self):

--- a/autonormalize/normalize.py
+++ b/autonormalize/normalize.py
@@ -79,7 +79,7 @@ def make_indexes(depdf):
     prim_key = depdf.deps.get_prim_key()
 
     if len(prim_key) > 1:
-
+        prim_key.sort()
         depdf.df.insert(0, '_'.join(prim_key), range(0, len(depdf.df)))
         depdf.index = ['_'.join(prim_key)]
 

--- a/autonormalize/normalize.py
+++ b/autonormalize/normalize.py
@@ -79,7 +79,7 @@ def make_indexes(depdf):
     prim_key = depdf.deps.get_prim_key()
 
     if len(prim_key) > 1:
-        prim_key.sort()
+
         depdf.df.insert(0, '_'.join(prim_key), range(0, len(depdf.df)))
         depdf.index = ['_'.join(prim_key)]
 

--- a/autonormalize/tests/test_normalize.py
+++ b/autonormalize/tests/test_normalize.py
@@ -178,3 +178,7 @@ def test_make_indexes():
     assert new_dfs[0][new_dfs[1].columns[0]][5] == val
     assert new_dfs[0][new_dfs[1].columns[0]][6] == val
     assert new_dfs[0][new_dfs[1].columns[0]][7] == val
+
+    # Make sure new column names are sorted
+    assert 'hemisphere_month' in new_dfs[0].columns
+    assert 'hemisphere_month' in new_dfs[1].columns


### PR DESCRIPTION
Added sort call to make sure new column names are always created the same.

Updated `test_make_indexes` to check that column names are returned with the expected names.